### PR TITLE
Supply `inline_policies` as Mapping[str, PolicyDocument]

### DIFF
--- a/cdk/cdk/alb_monitor_stack.py
+++ b/cdk/cdk/alb_monitor_stack.py
@@ -107,9 +107,9 @@ class ALBMonitorStack(cdk.Stack):
                     self, id='elb_full',
                     managed_policy_arn='arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess')
             ],
-            inline_policies=[
-                aws_iam.PolicyDocument.from_json(inline_policy_json_sqs),
-                aws_iam.PolicyDocument.from_json(inline_policy_json_logs)]
+            inline_policies={
+                "sqs": aws_iam.PolicyDocument.from_json(inline_policy_json_sqs),
+                "logs": aws_iam.PolicyDocument.from_json(inline_policy_json_logs)}
         )
 
 
@@ -187,9 +187,9 @@ class ALBMonitorStack(cdk.Stack):
                     self, id='elb_full2',
                     managed_policy_arn='arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess')
             ],
-            inline_policies=[
-                aws_iam.PolicyDocument.from_json(inline_policy_json_sqs),
-                aws_iam.PolicyDocument.from_json(inline_policy_json_logs)]
+            inline_policies={
+                "sqs": aws_iam.PolicyDocument.from_json(inline_policy_json_sqs),
+                "logs": aws_iam.PolicyDocument.from_json(inline_policy_json_logs)}
         )
 
         # The code for the ALB Alarm Check Queue Lambda


### PR DESCRIPTION
To fix this exception when trying to synth:

```
Traceback (most recent call last):
  File "/home/ec2-user/environment/aws-alb-target-group-load-shedding/cdk/app.py", line 16, in <module>
    alb_monitor_stack = ALBMonitorStack(app, "ALBMonitorStack")
  File "/home/ec2-user/.local/lib/python3.9/site-packages/jsii/_runtime.py", line 118, in __call__
    inst = super(JSIIMeta, cast(JSIIMeta, cls)).__call__(*args, **kwargs)
  File "/home/ec2-user/environment/aws-alb-target-group-load-shedding/cdk/cdk/alb_monitor_stack.py", line 98, in __init__
    alarm_lambda_execution_role = aws_iam.Role(
  File "/home/ec2-user/.local/lib/python3.9/site-packages/jsii/_runtime.py", line 118, in __call__
    inst = super(JSIIMeta, cast(JSIIMeta, cls)).__call__(*args, **kwargs)
  File "/home/ec2-user/.local/lib/python3.9/site-packages/aws_cdk/aws_iam/__init__.py", line 8323, in __init__
    jsii.create(Role, self, [scope, id, props])
  File "/home/ec2-user/.local/lib/python3.9/site-packages/jsii/_kernel/__init__.py", line 334, in create
    response = self.provider.create(
  File "/home/ec2-user/.local/lib/python3.9/site-packages/jsii/_kernel/providers/process.py", line 365, in create
    return self._process.send(request, CreateResponse)
  File "/home/ec2-user/.local/lib/python3.9/site-packages/jsii/_kernel/providers/process.py", line 342, in send
    raise RuntimeError(resp.error) from JavaScriptError(resp.stack)
RuntimeError: Passed to parameter props of new @aws-cdk/aws-iam.Role: Unable to deserialize value as @aws-cdk/aws-iam.RoleProps
├── 🛑 Failing value is an object
│      { '$jsii.struct': [Object] }
╰── 🔍 Failure reason(s):
    ╰─ Key 'inlinePolicies': Unable to deserialize value as map<@aws-cdk/aws-iam.PolicyDocument> | undefined
        ├── 🛑 Failing value is an array
        │      [ [Object], [Object] ]
        ╰── 🔍 Failure reason(s):
            ╰─ Value is an array
```